### PR TITLE
chore: release v0.1.2

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -2,8 +2,7 @@ name: release-plz
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   # Release unpublished packages.

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -5,7 +5,7 @@ on:
     branches: ["*"]
     paths: ["**/Cargo.toml", "**/Cargo.lock"]
   push:
-    branches: ["*"]
+    branches: [main]
     tags-ignore: ["v*"]
     paths: ["**/Cargo.toml", "**/Cargo.lock"]
   schedule:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -5,7 +5,7 @@ on:
     branches: ["*"]
     paths: ["**/*.rs", "**/Cargo.toml", "**/Cargo.lock"]
   push:
-    branches: ["*"]
+    branches: [main]
     tags-ignore: ["v*"]
     paths: ["**/*.rs", "**/Cargo.toml", "**/Cargo.lock"]
   workflow_dispatch:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -5,7 +5,7 @@ on:
     branches: ["*"]
     paths: ["**/*.rs", ".?rustfmt.toml"]
   push:
-    branches: ["*"]
+    branches: [main]
     tags-ignore: ["v*"]
     paths: ["**/*.rs", ".?rustfmt.toml"]
   workflow_dispatch:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -5,7 +5,7 @@ on:
     branches: ["*"]
     paths: ["**/*.rs", "typos.toml"]
   push:
-    branches: ["*"]
+    branches: [main]
     tags-ignore: ["v*"]
     paths: ["**/*.rs", "typos.toml"]
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2](https://github.com/antoniszymanski/gitcredential-rs/compare/v0.1.1...v0.1.2) - 2026-07-18
+
+### Other
+
+- restrict push triggers to main branch for all workflows
+- add release-plz workflow
+- *(renovate)* enable lock file maintenance
+- update actions/checkout action to v7
+- make Renovate not group single updates
+- update rust crate snafu to v0.9.1
+- update Renovate config
+- configure rustfmt to enforce Unix newline style
+- *(deps)* update softprops/action-gh-release action to v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "gitcredential"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "snafu",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitcredential"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "A library that provides an implementation of the git-credential input/output format"
 repository = "https://github.com/antoniszymanski/gitcredential-rs"


### PR DESCRIPTION



## 🤖 New release

* `gitcredential`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/antoniszymanski/gitcredential-rs/compare/v0.1.1...v0.1.2) - 2026-07-18

### Other

- restrict push triggers to main branch for all workflows
- add release-plz workflow
- *(renovate)* enable lock file maintenance
- update actions/checkout action to v7
- make Renovate not group single updates
- update rust crate snafu to v0.9.1
- update Renovate config
- configure rustfmt to enforce Unix newline style
- *(deps)* update softprops/action-gh-release action to v3
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).